### PR TITLE
Additional metadata

### DIFF
--- a/Emby.Plugins.AniList/AniListExternalId.cs
+++ b/Emby.Plugins.AniList/AniListExternalId.cs
@@ -1,4 +1,5 @@
-﻿using MediaBrowser.Controller.Entities.TV;
+﻿using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 
@@ -8,7 +9,7 @@ namespace Emby.Plugins.AniList
     {
         public bool Supports(IHasProviderIds item)
         {
-            return item is Series;
+            return item is Series || item is Movie;
         }
 
         public string Name

--- a/Emby.Plugins.AniList/AniListImageProvider.cs
+++ b/Emby.Plugins.AniList/AniListImageProvider.cs
@@ -1,0 +1,71 @@
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Logging;
+using MediaBrowser.Model.Providers;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Serialization;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Controller.Entities.Movies;
+
+namespace Emby.Plugins.AniList
+{
+    public class AniListImageProvider : IRemoteImageProvider
+    {
+        private readonly IHttpClient _httpClient;
+        private readonly IApplicationPaths _appPaths;
+        private readonly Api _api;
+        public AniListImageProvider(ILogManager logManager, IHttpClient httpClient, IApplicationPaths appPaths, IJsonSerializer jsonSerializer)
+        {
+            _httpClient = httpClient;
+            _appPaths = appPaths;
+            _api = new Api(logManager.GetLogger(Name), httpClient, jsonSerializer);
+        }
+
+        public string Name => "AniList";
+
+        public bool Supports(BaseItem item) => item is Movie || item is Series || item is Season;
+
+        public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
+        {
+            return new[] { ImageType.Primary };
+        }
+
+        public Task<IEnumerable<RemoteImageInfo>> GetImages(BaseItem item, LibraryOptions libraryOptions, CancellationToken cancellationToken)
+        {
+            var seriesId = item.GetProviderId(ProviderNames.AniList);
+            return GetImages(seriesId, cancellationToken);
+        }
+
+        public async Task<IEnumerable<RemoteImageInfo>> GetImages(string aid, CancellationToken cancellationToken)
+        {
+            var list = new List<RemoteImageInfo>();
+
+            if (!string.IsNullOrEmpty(aid))
+            {
+                var primary = _api.Get_ImageUrl(await _api.WebRequestAPI(_api.AniList_anime_link.Replace("{0}", aid), cancellationToken));
+                list.Add(new RemoteImageInfo
+                {
+                    ProviderName = Name,
+                    Type = ImageType.Primary,
+                    Url = primary
+                });
+            }
+            return list;
+        }
+
+        public Task<HttpResponseInfo> GetImageResponse(string url, CancellationToken cancellationToken)
+        {
+            return _httpClient.GetResponse(new HttpRequestOptions
+            {
+                CancellationToken = cancellationToken,
+                Url = url
+            });
+        }
+    }
+}

--- a/Emby.Plugins.AniList/AniListMetadataProvider.cs
+++ b/Emby.Plugins.AniList/AniListMetadataProvider.cs
@@ -62,6 +62,13 @@ namespace Emby.Plugins.AniList
             result.Item.OriginalTitle = WebContent.data.Media.title.native;
 
             result.People = await _api.GetPersonInfo(WebContent.data.Media.id, cancellationToken);
+            foreach (var studio in _api.Get_Studio(WebContent))
+                result.Item.AddStudio(studio);
+            foreach (var tag in _api.Get_Tag(WebContent))
+                result.Item.AddTag(tag);
+            if (Equals_check.Compare_strings("youtube", WebContent.data.Media.trailer.site)) {
+                result.Item.AddTrailerUrl("https://youtube.com/watch?v=" + WebContent.data.Media.trailer.id);
+            }
             result.Item.SetProviderId(ProviderNames.AniList, WebContent.data.Media.id.ToString());
             result.Item.Overview = WebContent.data.Media.description;
             try

--- a/Emby.Plugins.AniList/AniListMetadataProvider.cs
+++ b/Emby.Plugins.AniList/AniListMetadataProvider.cs
@@ -1,0 +1,135 @@
+﻿using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Logging;
+using MediaBrowser.Model.Providers;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Serialization;
+using Emby.Anime;
+
+//API v2
+namespace Emby.Plugins.AniList
+{
+    public class AniListMetadataProvider<T, U> : IRemoteMetadataProvider<T, U>, IHasOrder where T : BaseItem,IHasLookupInfo<U>,new() where U : ItemLookupInfo,new()
+    {
+        protected readonly IHttpClient _httpClient;
+        protected readonly IApplicationPaths _paths;
+        protected readonly ILogger _log;
+        protected readonly Api _api;
+        public int Order => 8;
+        public string Name => "AniList";
+
+        public AniListMetadataProvider(IApplicationPaths appPaths, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer)
+        {
+            _log = logManager.GetLogger(Name);
+            _httpClient = httpClient;
+            _api = new Api(_log, httpClient, jsonSerializer);
+            _paths = appPaths;
+        }
+
+        protected virtual MetadataResult<T> _GetMetadata(MetadataResult<T> result, RootObject WebContent)
+        {
+            return result;
+        }
+
+        public async Task<MetadataResult<T>> GetMetadata(U info, CancellationToken cancellationToken)
+        {
+            RootObject WebContent = null;
+
+            var aid = info.GetProviderId(ProviderNames.AniList);
+            if (string.IsNullOrEmpty(aid))
+            {
+                _log.Info("Start AniList... Searching(" + info.Name + ")");
+                aid = await _api.FindSeries(info.Name, cancellationToken);
+            }
+
+            if (!string.IsNullOrEmpty(aid))
+            {
+                WebContent = await _api.WebRequestAPI(_api.AniList_anime_link.Replace("{0}", aid), cancellationToken);
+            }
+
+            var result = new MetadataResult<T>();
+
+            result.Item = new T();
+            result.HasMetadata = true;
+
+            result.Item.Name = _api.SelectName(WebContent, info.MetadataLanguage);
+            result.Item.OriginalTitle = WebContent.data.Media.title.native;
+
+            result.People = await _api.GetPersonInfo(WebContent.data.Media.id, cancellationToken);
+            result.Item.SetProviderId(ProviderNames.AniList, WebContent.data.Media.id.ToString());
+            result.Item.Overview = WebContent.data.Media.description;
+            try
+            {
+                StartDate startDate = WebContent.data.Media.startDate;
+                DateTime date = new DateTime(startDate.year, startDate.month, startDate.day);
+                date = date.ToUniversalTime();
+                result.Item.PremiereDate = date;
+                result.Item.ProductionYear = date.Year;
+            }
+            catch (Exception) { }
+            try
+            {
+                EndDate endDate = WebContent.data.Media.endDate;
+                DateTime date = new DateTime(endDate.year, endDate.month, endDate.day);
+                date = date.ToUniversalTime();
+                result.Item.EndDate = date;
+            }
+            catch (Exception) { }
+            int episodes = WebContent.data.Media.episodes;
+            int duration = WebContent.data.Media.duration;
+            if (episodes > 0 && duration > 0){
+                // minutes to microseconds, needs to x10 to display correctly for some reason
+                result.Item.RunTimeTicks = episodes * duration * (long)600000000;
+            }
+            try
+            {
+                //AniList has a max rating of 5
+                result.Item.CommunityRating = (WebContent.data.Media.averageScore / 10);
+            }
+            catch (Exception) { }
+            foreach (var genre in _api.Get_Genre(WebContent))
+                result.Item.AddGenre(genre);
+            GenreHelper.CleanupGenres(result.Item);
+
+            return _GetMetadata(result, WebContent);
+        }
+
+        public async Task<IEnumerable<RemoteSearchResult>> GetSearchResults(U searchInfo, CancellationToken cancellationToken)
+        {
+            var results = new Dictionary<string, RemoteSearchResult>();
+
+            var aid = searchInfo.GetProviderId(ProviderNames.AniList);
+            if (!string.IsNullOrEmpty(aid))
+            {
+                if (!results.ContainsKey(aid))
+                    results.Add(aid, await _api.GetAnime(aid, cancellationToken));
+            }
+
+            if (!string.IsNullOrEmpty(searchInfo.Name))
+            {
+                List<string> ids = await _api.Search_GetSeries_list(searchInfo.Name, cancellationToken);
+                foreach (string a in ids)
+                {
+                    results.Add(a, await _api.GetAnime(a, cancellationToken));
+                }
+            }
+
+            return results.Values;
+        }
+
+        public Task<HttpResponseInfo> GetImageResponse(string url, CancellationToken cancellationToken)
+        {
+            return _httpClient.GetResponse(new HttpRequestOptions
+            {
+                CancellationToken = cancellationToken,
+                Url = url
+            });
+        }
+    }
+}

--- a/Emby.Plugins.AniList/AniListMovieProvider.cs
+++ b/Emby.Plugins.AniList/AniListMovieProvider.cs
@@ -1,0 +1,18 @@
+﻿using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Logging;
+using MediaBrowser.Model.Serialization;
+using MediaBrowser.Controller.Entities.Movies;
+
+//API v2
+namespace Emby.Plugins.AniList
+{
+    public class AniListMovieProvider : AniListMetadataProvider<Movie, MovieInfo>
+    {
+        public AniListMovieProvider(IApplicationPaths appPaths, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer) : base(appPaths, httpClient, logManager, jsonSerializer)
+        {
+            
+        }
+    }
+}

--- a/Emby.Plugins.AniList/AniListSeriesProvider.cs
+++ b/Emby.Plugins.AniList/AniListSeriesProvider.cs
@@ -76,6 +76,19 @@ namespace Emby.Plugins.AniList
                 }
                 catch (Exception) { }
                 try
+                {
+                    string status = WebContent.data.Media.status;
+                    if (status == Status.RELEASING || status == Status.NOT_YET_RELEASED)
+                    {
+                        result.Item.Status = SeriesStatus.Continuing;
+                    }
+                    else
+                    {
+                        result.Item.Status = SeriesStatus.Ended;
+                    }
+                }
+                catch (Exception) { }
+                try
                     //AniList has a max rating of 5
                     result.Item.CommunityRating = (WebContent.data.Media.averageScore / 10);
                 }

--- a/Emby.Plugins.AniList/AniListSeriesProvider.cs
+++ b/Emby.Plugins.AniList/AniListSeriesProvider.cs
@@ -1,4 +1,4 @@
-using MediaBrowser.Common.Configuration;
+﻿using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
@@ -89,6 +89,17 @@ namespace Emby.Plugins.AniList
                 }
                 catch (Exception) { }
                 try
+                {
+                    int episodes = WebContent.data.Media.episodes;
+                    int duration = WebContent.data.Media.duration;
+                    if (episodes > 0 && duration > 0){
+                        // minutes to microseconds, needs to x10 to display correctly for some reason
+                        result.Item.RunTimeTicks = episodes * duration * (long)600000000;
+                    }
+                }
+                catch (Exception) { }
+                try
+                {
                     //AniList has a max rating of 5
                     result.Item.CommunityRating = (WebContent.data.Media.averageScore / 10);
                 }

--- a/Emby.Plugins.AniList/AniListSeriesProvider.cs
+++ b/Emby.Plugins.AniList/AniListSeriesProvider.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
@@ -60,6 +60,22 @@ namespace Emby.Plugins.AniList
                 result.Item.Overview = WebContent.data.Media.description;
                 try
                 {
+                    StartDate startDate = WebContent.data.Media.startDate;
+                    DateTime date = new DateTime(startDate.year, startDate.month, startDate.day);
+                    date = date.ToUniversalTime();
+                    result.Item.PremiereDate = date;
+                    result.Item.ProductionYear = date.Year;
+                }
+                catch (Exception) { }
+                try
+                {
+                    EndDate endDate = WebContent.data.Media.endDate;
+                    DateTime date = new DateTime(endDate.year, endDate.month, endDate.day);
+                    date = date.ToUniversalTime();
+                    result.Item.EndDate = date;
+                }
+                catch (Exception) { }
+                try
                     //AniList has a max rating of 5
                     result.Item.CommunityRating = (WebContent.data.Media.averageScore / 10);
                 }

--- a/Emby.Plugins.AniList/AniListSeriesProvider.cs
+++ b/Emby.Plugins.AniList/AniListSeriesProvider.cs
@@ -84,16 +84,12 @@ namespace Emby.Plugins.AniList
                 result.Item.EndDate = date;
             }
             catch (Exception) { }
-            try
-            {
-                int episodes = WebContent.data.Media.episodes;
-                int duration = WebContent.data.Media.duration;
-                if (episodes > 0 && duration > 0){
-                    // minutes to microseconds, needs to x10 to display correctly for some reason
-                    result.Item.RunTimeTicks = episodes * duration * (long)600000000;
-                }
+            int episodes = WebContent.data.Media.episodes;
+            int duration = WebContent.data.Media.duration;
+            if (episodes > 0 && duration > 0){
+                // minutes to microseconds, needs to x10 to display correctly for some reason
+                result.Item.RunTimeTicks = episodes * duration * (long)600000000;
             }
-            catch (Exception) { }
             try
             {
                 //AniList has a max rating of 5
@@ -114,19 +110,15 @@ namespace Emby.Plugins.AniList
 
             if (result.HasMetadata)
             {
-                try
+                string status = WebContent.data.Media.status;
+                if (status == Status.RELEASING || status == Status.NOT_YET_RELEASED)
                 {
-                    string status = WebContent.data.Media.status;
-                    if (status == Status.RELEASING || status == Status.NOT_YET_RELEASED)
-                    {
-                        result.Item.Status = SeriesStatus.Continuing;
-                    }
-                    else
-                    {
-                        result.Item.Status = SeriesStatus.Ended;
-                    }
+                    result.Item.Status = SeriesStatus.Continuing;
                 }
-                catch (Exception) { }
+                else
+                {
+                    result.Item.Status = SeriesStatus.Ended;
+                }
             }
             return result;
         }

--- a/Emby.Plugins.AniList/ApiModel.cs
+++ b/Emby.Plugins.AniList/ApiModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -29,6 +29,15 @@ namespace Emby.Plugins.AniList
         public int year { get; set; }
         public int month { get; set; }
         public int day { get; set; }
+    }
+
+    public class Status
+    {
+        public static string FINISHED   { get { return "FINISHED"; } }
+        public static string RELEASING   { get { return "RELEASING"; } }
+        public static string NOT_YET_RELEASED    { get { return "NOT_YET_RELEASED"; } }
+        public static string CANCELLED { get { return "CANCELLED"; } }
+        public static string HIATUS   { get { return "HIATUS"; } }
     }
 
     public class Medium

--- a/Emby.Plugins.AniList/ApiModel.cs
+++ b/Emby.Plugins.AniList/ApiModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -50,6 +50,7 @@ namespace Emby.Plugins.AniList
         public int averageScore { get; set; }
         public int popularity { get; set; }
         public int episodes { get; set; }
+        public int duration { get; set; }
         public string season { get; set; }
         public string hashtag { get; set; }
         public bool isAdult { get; set; }
@@ -93,6 +94,7 @@ namespace Emby.Plugins.AniList
         public string type { get; set; }
         public string status { get; set; }
         public int episodes { get; set; }
+        public int duration { get; set; }
         public object chapters { get; set; }
         public object volumes { get; set; }
         public string season { get; set; }

--- a/Emby.Plugins.AniList/ApiModel.cs
+++ b/Emby.Plugins.AniList/ApiModel.cs
@@ -33,11 +33,11 @@ namespace Emby.Plugins.AniList
 
     public class Status
     {
-        public static string FINISHED   { get { return "FINISHED"; } }
-        public static string RELEASING   { get { return "RELEASING"; } }
-        public static string NOT_YET_RELEASED    { get { return "NOT_YET_RELEASED"; } }
+        public static string FINISHED { get { return "FINISHED"; } }
+        public static string RELEASING  { get { return "RELEASING"; } }
+        public static string NOT_YET_RELEASED { get { return "NOT_YET_RELEASED"; } }
         public static string CANCELLED { get { return "CANCELLED"; } }
-        public static string HIATUS   { get { return "HIATUS"; } }
+        public static string HIATUS { get { return "HIATUS"; } }
     }
 
     public class Medium

--- a/Emby.Plugins.AniList/ApiModel.cs
+++ b/Emby.Plugins.AniList/ApiModel.cs
@@ -104,6 +104,9 @@ namespace Emby.Plugins.AniList
         public List<string> genres { get; set; }
         public List<object> synonyms { get; set; }
         public object nextAiringEpisode { get; set; }
+        public Studios studios { get; set; }
+        public Trailer trailer { get; set; }
+        public List<Tag> tags { get; set; }
     }
     public class PageInfo
     {
@@ -165,6 +168,33 @@ namespace Emby.Plugins.AniList
     {
         public PageInfo pageInfo { get; set; }
         public List<Edge> edges { get; set; }
+    }
+
+    public class StudioNode
+    {
+        public string name { get; set; }
+    }
+
+    public class StudioEdge
+    {
+        public StudioNode node { get; set; }
+    }
+
+    public class Studios
+    {
+        public PageInfo pageInfo { get; set; }
+        public List<StudioEdge> edges { get; set; }
+    }
+
+    public class Trailer
+    {
+        public string id { get; set; }
+        public string site { get; set; }
+    }
+
+    public class Tag
+    {
+        public string name { get; set; }
     }
 
 

--- a/Emby.Plugins.AniList/GenreHelper.cs
+++ b/Emby.Plugins.AniList/GenreHelper.cs
@@ -1,4 +1,5 @@
-﻿using MediaBrowser.Controller.Entities.TV;
+﻿using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -208,34 +209,34 @@ namespace Emby.Anime
             {"Psychological Thriller", "Thriller"}
         };
 
-        public static void CleanupGenres(Series series)
+        public static void CleanupGenres(BaseItem item)
         {
-            series.Genres = RemoveRedundantGenres(series.Genres)
+            item.Genres = RemoveRedundantGenres(item.Genres)
                                        .Distinct(StringComparer.OrdinalIgnoreCase)
                                        .ToArray();
 
-            TidyGenres(series);
+            TidyGenres(item);
 
-            series.Genres = series.Genres.Except(new[] { "Animation", "Anime" }).ToArray();
+            item.Genres = item.Genres.Except(new[] { "Animation", "Anime" }).ToArray();
 
-            series.Genres = series.Genres.ToArray();
+            item.Genres = item.Genres.ToArray();
 
-            if (!series.Genres.Contains("Anime", StringComparer.OrdinalIgnoreCase))
+            if (!item.Genres.Contains("Anime", StringComparer.OrdinalIgnoreCase))
             {
-                series.Genres = series.Genres.Except(new[] { "Animation" }).ToArray();
+                item.Genres = item.Genres.Except(new[] { "Animation" }).ToArray();
 
-                series.AddGenre("Anime");
+                item.AddGenre("Anime");
             }
 
-            series.Genres = series.Genres.OrderBy(i => i).ToArray();
+            item.Genres = item.Genres.OrderBy(i => i).ToArray();
         }
 
-        public static void TidyGenres(Series series)
+        public static void TidyGenres(BaseItem item)
         {
             var genres = new HashSet<string>();
-            var tags = new HashSet<string>(series.Tags);
+            var tags = new HashSet<string>(item.Tags);
 
-            foreach (string genre in series.Genres)
+            foreach (string genre in item.Genres)
             {
                 string mapped;
                 if (GenreMappings.TryGetValue(genre, out mapped))
@@ -251,8 +252,8 @@ namespace Emby.Anime
                 }
             }
 
-            series.Genres = genres.ToArray();
-            series.Tags = tags.ToArray();
+            item.Genres = genres.ToArray();
+            item.Tags = tags.ToArray();
         }
 
         public static IEnumerable<string> RemoveRedundantGenres(IEnumerable<string> genres)

--- a/Emby.Plugins.AniList/api.cs
+++ b/Emby.Plugins.AniList/api.cs
@@ -19,7 +19,7 @@ namespace Emby.Plugins.AniList
     /// <summary>
     /// Based on the new API from AniList
     /// 🛈 This code works with the API Interface (v2) from AniList
-    /// 🛈 https://anilist.gitbooks.io/anilist-apiv2-docs
+    /// 🛈 https://anilist.gitbook.io/anilist-apiv2-docs
     /// 🛈 THIS IS AN UNOFFICAL API INTERFACE FOR EMBY
     /// </summary>
     public class Api
@@ -44,6 +44,7 @@ query ($query: String, $type: MediaType) {
       averageScore
       popularity
       episodes
+      duration
       season
       hashtag
       isAdult
@@ -89,6 +90,7 @@ query ($query: String, $type: MediaType) {
     type
     status
     episodes
+    duration
     chapters
     volumes
     season

--- a/Emby.Plugins.AniList/api.cs
+++ b/Emby.Plugins.AniList/api.cs
@@ -61,52 +61,53 @@ query ($query: String, $type: MediaType) {
     }
   }
 }&variables={ ""query"":""{0}"",""type"":""ANIME""}";
-        public string AniList_anime_link = @"https://graphql.anilist.co/api/v2?query=query($id: Int!, $type: MediaType) {
-  Media(id: $id, type: $type)
-        {
-            id
-            title {
-                romaji
-                english
-              native
-      userPreferred
-            }
-            startDate {
-                year
-                month
-              day
-            }
-            endDate {
-                year
-                month
-              day
-            }
-            coverImage {
-                large
-                medium
-            }
-            bannerImage
-            format
-    type
-    status
-    episodes
-    duration
-    chapters
-    volumes
-    season
-    description
-    averageScore
-    meanScore
-    genres
-    synonyms
-    nextAiringEpisode {
-                airingAt
-                timeUntilAiring
-      episode
-    }
+        public string AniList_anime_link = @"https://graphql.anilist.co/api/v2?query=
+query($id: Int!, $type: MediaType) {
+    Media(id: $id, type: $type) {
+        id
+        title {
+            romaji
+            english
+            native
+            userPreferred
         }
-    }&variables={ ""id"":""{0}"",""type"":""ANIME""}";
-        private const string AniList_anime_char_link = @"https://graphql.anilist.co/api/v2?query=query($id: Int!, $type: MediaType, $page: Int = 1) {
+        startDate {
+            year
+            month
+            day
+        }
+        endDate {
+            year
+            month
+            day
+        }
+        coverImage {
+            large
+            medium
+        }
+        bannerImage
+        format
+        type
+        status
+        episodes
+        duration
+        chapters
+        volumes
+        season
+        description
+        averageScore
+        meanScore
+        genres
+        synonyms
+        nextAiringEpisode {
+            airingAt
+            timeUntilAiring
+            episode
+        }
+    }
+}&variables={ ""id"":""{0}"",""type"":""ANIME""}";
+        private const string AniList_anime_char_link = @"https://graphql.anilist.co/api/v2?query=
+query($id: Int!, $type: MediaType, $page: Int = 1) {
   Media(id: $id, type: $type) {
     id
     characters(page: $page, sort: [ROLE]) {


### PR DESCRIPTION
Extends the amount of metadata extracted from AniList and used in the result.

- startDate + endDate were properly set in an older version (before the split from the Emby.Plugins.Anime-repo), but seem to somehow have gotten lost during that transition
- status gets properly determined by the status-field of the result instead of relying on the endDate (which is not set for all entries)
- runtime gets calculated by multplying number of episodes by runtime per episode in minutes, which is then converted into microseconds (wierdly enough I needed to multiply microseconds x10 for it to show correctly in the UI, maybe a bug?)

Hopefully the quality is fine.
Been a while since I used C#.
Thanks again for opening up the repo so I could finally fix these :)