### PR TITLE
Name comparison fix + option to disable character import

### DIFF
--- a/Emby.Plugins.AniList/AniListMetadataProvider.cs
+++ b/Emby.Plugins.AniList/AniListMetadataProvider.cs
@@ -17,16 +17,18 @@ namespace Emby.Plugins.AniList
     public class AniListMetadataProvider<T, U> : IRemoteMetadataProvider<T, U>, IHasOrder where T : BaseItem,IHasLookupInfo<U>,new() where U : ItemLookupInfo,new()
     {
         protected readonly IHttpClient _httpClient;
+        protected readonly IConfigurationManager _config;
         protected readonly IApplicationPaths _paths;
         protected readonly ILogger _log;
         protected readonly Api _api;
         public int Order => 8;
         public string Name => "AniList";
 
-        public AniListMetadataProvider(IApplicationPaths appPaths, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer)
+        public AniListMetadataProvider(IApplicationPaths appPaths, IConfigurationManager config, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer)
         {
             _log = logManager.GetLogger(Name);
             _httpClient = httpClient;
+            _config = config;
             _api = new Api(_log, httpClient, jsonSerializer);
             _paths = appPaths;
         }
@@ -69,7 +71,7 @@ namespace Emby.Plugins.AniList
 
             result.Item.OriginalTitle = media.title.native;
 
-            result.People = await _api.GetPersonInfo(media.id, cancellationToken);
+            result.People = await _api.GetPersonInfo(media.id, _config.GetAniListListOptions(), cancellationToken);
             foreach (var studio in _api.Get_Studio(media))
                 result.Item.AddStudio(studio);
             foreach (var tag in _api.Get_Tag(media))

--- a/Emby.Plugins.AniList/AniListMetadataProvider.cs
+++ b/Emby.Plugins.AniList/AniListMetadataProvider.cs
@@ -108,8 +108,7 @@ namespace Emby.Plugins.AniList
             }
             try
             {
-                //AniList has a max rating of 5
-                result.Item.CommunityRating = (media.averageScore / 10);
+                result.Item.CommunityRating = ((float)media.averageScore / 10);
             }
             catch (Exception) { }
             foreach (var genre in _api.Get_Genre(media))

--- a/Emby.Plugins.AniList/AniListMovieProvider.cs
+++ b/Emby.Plugins.AniList/AniListMovieProvider.cs
@@ -10,7 +10,7 @@ namespace Emby.Plugins.AniList
 {
     public class AniListMovieProvider : AniListMetadataProvider<Movie, MovieInfo>
     {
-        public AniListMovieProvider(IApplicationPaths appPaths, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer) : base(appPaths, httpClient, logManager, jsonSerializer)
+        public AniListMovieProvider(IApplicationPaths appPaths, IConfigurationManager config, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer) : base(appPaths, config, httpClient, logManager, jsonSerializer)
         {
             
         }

--- a/Emby.Plugins.AniList/AniListSeriesProvider.cs
+++ b/Emby.Plugins.AniList/AniListSeriesProvider.cs
@@ -20,7 +20,7 @@ namespace Emby.Plugins.AniList
 {
     public class AniListSeriesProvider : AniListMetadataProvider<Series, SeriesInfo>
     {
-        public AniListSeriesProvider(IApplicationPaths appPaths, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer) : base(appPaths, httpClient, logManager, jsonSerializer)
+        public AniListSeriesProvider(IApplicationPaths appPaths, IConfigurationManager config, IHttpClient httpClient, ILogManager logManager, IJsonSerializer jsonSerializer) : base(appPaths, config, httpClient, logManager, jsonSerializer)
         {
             
         }

--- a/Emby.Plugins.AniList/Configuration/anilist.html
+++ b/Emby.Plugins.AniList/Configuration/anilist.html
@@ -13,16 +13,6 @@
                 </div>
             </div>
 
-            <div class="checkboxContainer checkboxContainer-withDescription">
-                <label>
-                    <input is="emby-checkbox" type="checkbox" id="fetchRating" />
-                    <span>Download character metadata</span>
-                </label>
-                <div class="fieldDescription checkboxFieldDescription">
-                    Download metadata for characters as if they are actors. 
-                </div>
-            </div>
-
             <div>
                 <button is="emby-button" type="submit" class="raised button-submit block"><span>${Save}</span></button>
             </div>

--- a/Emby.Plugins.AniList/Configuration/anilist.html
+++ b/Emby.Plugins.AniList/Configuration/anilist.html
@@ -1,0 +1,31 @@
+﻿<div is="emby-scroller" class="view flex flex-direction-column scrollFrameY flex-grow" data-horizontal="false" data-forcescrollbar="true" data-centerfocus="true" data-bindheader="true" data-controller="__plugin/anilistjs" data-title="AniList">
+    <div class="scrollSlider flex-grow flex-direction-column padded-left padded-left-page padded-right padded-top-page padded-bottom-page">
+
+        <form class="auto-center">
+
+            <div class="checkboxContainer checkboxContainer-withDescription">
+                <label>
+                    <input is="emby-checkbox" type="checkbox" id="downloadCharacters" />
+                    <span>Download character metadata</span>
+                </label>
+                <div class="fieldDescription checkboxFieldDescription">
+                    Download metadata for characters as if they are actors. 
+                </div>
+            </div>
+
+            <div class="checkboxContainer checkboxContainer-withDescription">
+                <label>
+                    <input is="emby-checkbox" type="checkbox" id="fetchRating" />
+                    <span>Download character metadata</span>
+                </label>
+                <div class="fieldDescription checkboxFieldDescription">
+                    Download metadata for characters as if they are actors. 
+                </div>
+            </div>
+
+            <div>
+                <button is="emby-button" type="submit" class="raised button-submit block"><span>${Save}</span></button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/Emby.Plugins.AniList/Configuration/anilist.js
+++ b/Emby.Plugins.AniList/Configuration/anilist.js
@@ -1,0 +1,63 @@
+﻿define(['baseView', 'loading', 'emby-input', 'emby-button', 'emby-checkbox', 'emby-scroller'], function(BaseView, loading) {
+    'use strict';
+
+    function loadPage(page, config)
+    {
+
+        page.querySelector('#downloadCharacters').checked = config.ShouldDownloadCharacters || '';
+
+        loading.hide();
+    }
+
+    function onSubmit(e)
+    {
+
+        e.preventDefault();
+
+        loading.show();
+
+        var form = this;
+
+        ApiClient.getNamedConfiguration("anilist").then(function(config) {
+
+            config.ShouldDownloadCharacters = form.querySelector('#downloadCharacters').checked;
+
+            ApiClient.updateNamedConfiguration("anilist", config).then(Dashboard.processServerConfigurationUpdateResult);
+        });
+
+    // Disable default form submission
+    return false;
+}
+
+function getConfig()
+{
+
+    return ApiClient.getNamedConfiguration("anilist");
+}
+
+function View(view, params)
+{
+    BaseView.apply(this, arguments);
+
+    view.querySelector('form').addEventListener('submit', onSubmit);
+}
+
+Object.assign(View.prototype, BaseView.prototype);
+
+View.prototype.onResume = function(options) {
+
+    BaseView.prototype.onResume.apply(this, arguments);
+
+    loading.show();
+
+    var page = this.view;
+
+    getConfig().then(function(response) {
+
+        loadPage(page, response);
+    });
+};
+
+return View;
+
+});

--- a/Emby.Plugins.AniList/ConfigurationExtension.cs
+++ b/Emby.Plugins.AniList/ConfigurationExtension.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using MediaBrowser.Common.Configuration;
+
+namespace Emby.Plugins.AniList
+{
+    public static class ConfigurationExtension
+    {
+        public static AniListOptions GetAniListListOptions(this IConfigurationManager manager)
+        {
+            return manager.GetConfiguration<AniListOptions>("anilist");
+        }
+    }
+
+    public class AniListConfigurationFactory : IConfigurationFactory
+    {
+        public IEnumerable<ConfigurationStore> GetConfigurations()
+        {
+            return new ConfigurationStore[]
+            {
+                new ConfigurationStore
+                {
+                    Key = "anilist",
+                    ConfigurationType = typeof (AniListOptions)
+                }
+            };
+        }
+    }
+
+    public class AniListOptions
+    {
+        public bool ShouldDownloadCharacters { get; set; }
+
+        public AniListOptions()
+        {
+            ShouldDownloadCharacters = true;
+        }
+    }
+}

--- a/Emby.Plugins.AniList/Emby.Plugins.AniList.csproj
+++ b/Emby.Plugins.AniList/Emby.Plugins.AniList.csproj
@@ -7,16 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Configuration\**" />
-    <EmbeddedResource Remove="Configuration\**" />
-    <None Remove="Configuration\**" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <None Remove="Configuration\anilist.html" />
+    <None Remove="Configuration\anilist.js" />
     <None Remove="thumb.png" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Configuration\anilist.html" />
+    <EmbeddedResource Include="Configuration\anilist.js" />
     <EmbeddedResource Include="thumb.png" />
   </ItemGroup>
 

--- a/Emby.Plugins.AniList/Plugin.cs
+++ b/Emby.Plugins.AniList/Plugin.cs
@@ -29,7 +29,22 @@ namespace Emby.Plugins.AniList
 
         public IEnumerable<PluginPageInfo> GetPages()
         {
-            return Array.Empty<PluginPageInfo>();
+            return new[]
+            {
+                new PluginPageInfo
+                {
+                    Name = "anilist",
+                    EmbeddedResourcePath = GetType().Namespace + ".Configuration.anilist.html",
+                    EnableInMainMenu = true,
+                    MenuIcon = "dvr"
+                },
+
+                new PluginPageInfo
+                {
+                    Name = "anilistjs",
+                    EmbeddedResourcePath = GetType().Namespace + ".Configuration.anilist.js"
+                }
+            };
         }
 
         private Guid _id = new Guid("043B75CD-FC2C-49CC-ACCC-4D1D60A297C5");

--- a/Emby.Plugins.AniList/api.cs
+++ b/Emby.Plugins.AniList/api.cs
@@ -311,16 +311,6 @@ query($id: Int!, $type: MediaType, $staffLanguage: StaffLanguage, $page: Int = 1
         }
 
         /// <summary>
-        /// API call too get the rating
-        /// </summary>
-        /// <param name="WebContent"></param>
-        /// <returns></returns>
-        public string Get_Rating(BaseMedia media)
-        {
-            return (media.averageScore / 10).ToString();
-        }
-
-        /// <summary>
         /// API call to get the description
         /// </summary>
         /// <param name="WebContent"></param>

--- a/Emby.Plugins.AniList/api.cs
+++ b/Emby.Plugins.AniList/api.cs
@@ -224,7 +224,7 @@ query($id: Int!, $type: MediaType, $staffLanguage: StaffLanguage, $page: Int = 1
             return media.title?.romaji;
         }
 
-        public async Task<List<PersonInfo>> GetPersonInfo(int id, CancellationToken cancellationToken)
+        public async Task<List<PersonInfo>> GetPersonInfo(int id, AniListOptions config, CancellationToken cancellationToken)
         {
             List<PersonInfo> lpi = new List<PersonInfo>();
             RootObject WebContent = await WebRequestAPI(AniList_anime_char_link.Replace("{0}", id.ToString()), cancellationToken);
@@ -234,17 +234,21 @@ query($id: Int!, $type: MediaType, $staffLanguage: StaffLanguage, $page: Int = 1
                 {
                     VoiceActor va = edge.voiceActors[0];
                     PersonInfo actor = new PersonInfo();
-                    PersonInfo character = new PersonInfo();
                     actor.Name = va.name.first + " " + va.name.last;
                     actor.ImageUrl = va.image.large;
                     actor.Role = edge.node.name.first + " " + edge.node.name.last;
                     actor.Type = PersonType.Actor;
-                    character.Name = actor.Role;
-                    character.ImageUrl = edge.node.image.large;
-                    character.Role = actor.Name;
-                    character.Type = PersonType.GuestStar;
                     lpi.Add(actor);
-                    lpi.Add(character);
+
+                    if (config.ShouldDownloadCharacters)
+                    {
+                        PersonInfo character = new PersonInfo();
+                        character.Name = actor.Role;
+                        character.ImageUrl = edge.node.image.large;
+                        character.Role = actor.Name;
+                        character.Type = PersonType.GuestStar;
+                        lpi.Add(character);
+                    }
                 }
             }
             return lpi;

--- a/Emby.Plugins.AniList/equals_check.cs
+++ b/Emby.Plugins.AniList/equals_check.cs
@@ -40,6 +40,7 @@ namespace Emby.Plugins.AniList
             a = a.Replace("-", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("`", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("'", "", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("’", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("&", "and", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("(", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace(")", "", StringComparison.OrdinalIgnoreCase);
@@ -178,7 +179,7 @@ namespace Emby.Plugins.AniList
 
             a = a.ToLower().Replace(" ", "", StringComparison.OrdinalIgnoreCase).Trim().Replace(".", "", StringComparison.OrdinalIgnoreCase);
             b = b.ToLower().Replace(" ", "", StringComparison.OrdinalIgnoreCase).Trim().Replace(".", "", StringComparison.OrdinalIgnoreCase);
-
+                
             if (string.Equals(Clear_name(a), Clear_name(b), StringComparison.OrdinalIgnoreCase))
                 return true;
             if (string.Equals(Clear_name_step2(a), Clear_name_step2(b), StringComparison.OrdinalIgnoreCase))

--- a/Emby.Plugins.AniList/equals_check.cs
+++ b/Emby.Plugins.AniList/equals_check.cs
@@ -35,6 +35,8 @@ namespace Emby.Plugins.AniList
         public static string Clear_name(string a)
         {
             a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \(.*?\)"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
+            a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \[tvdb.*?\]"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
+            a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \{tvdb.*?\}"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
 
             a = a.Replace(".", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("-", " ", StringComparison.OrdinalIgnoreCase);
@@ -86,6 +88,8 @@ namespace Emby.Plugins.AniList
             a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \(.*?\)"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
 
             a = a.Replace(".", " ", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("!", " ", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("?", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("-", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("`", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("'", "", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
This MR fixes title comparison issue caused by `’` symbol in some titles. It also adds an option to disable character import (see https://github.com/MediaBrowser/Emby.Plugins.AniList/issues/3) and reactors rating calculation